### PR TITLE
feat: add support for windows

### DIFF
--- a/color.go
+++ b/color.go
@@ -3,8 +3,6 @@ package check
 import (
 	"os"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -23,14 +21,6 @@ func init() {
 func wantColor() bool {
 	return strings.Contains(os.Getenv("TERM"), "color") &&
 		(isTerminal() || os.Getenv("GO_TEST_COLOR") != "")
-}
-
-func isTerminal() bool {
-	if ioctlReadTermios == 0 {
-		return false
-	}
-	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), ioctlReadTermios)
-	return err == nil
 }
 
 func colouredDiff(diff string) string {

--- a/color_bsd.go
+++ b/color_bsd.go
@@ -2,6 +2,13 @@
 
 package check
 
-import "golang.org/x/sys/unix"
+import (
+	"os"
 
-const ioctlReadTermios = unix.TIOCGETA
+	"golang.org/x/sys/unix"
+)
+
+func isTerminal() bool {
+	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TIOCGETA)
+	return err == nil
+}

--- a/color_linux.go
+++ b/color_linux.go
@@ -2,6 +2,13 @@
 
 package check
 
-import "golang.org/x/sys/unix"
+import (
+	"os"
 
-const ioctlReadTermios = unix.TCGETS
+	"golang.org/x/sys/unix"
+)
+
+func isTerminal() bool {
+	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETS)
+	return err == nil
+}

--- a/color_other.go
+++ b/color_other.go
@@ -1,5 +1,7 @@
-// +build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!openbsd
+// +build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!openbsd,!windows
 
 package check
 
-const ioctlReadTermios = uint(0)
+func isTerminal() bool {
+	return false
+}

--- a/color_windows.go
+++ b/color_windows.go
@@ -1,0 +1,14 @@
+// +build windows
+
+package check
+
+import (
+	"os"
+	"syscall"
+)
+
+func isTerminal() bool {
+	var mode uint32
+	err := syscall.GetConsoleMode(syscall.Handle(os.Stdout.Fd()), &mode)
+	return err == nil
+}


### PR DESCRIPTION
Previously, trying to run on Windows:

```
$ uname
MINGW64_NT-10.0-18362
$ go test
# github.com/powerman/check [github.com/powerman/check.test]
.\color.go:32:12: undefined: unix.IoctlGetTermios
FAIL    github.com/powerman/check [build failed]
```

I think this change should fix it, though I haven't been able to check the other platforms.
